### PR TITLE
Reset watches upon reconnecting to the same ZK host

### DIFF
--- a/src/erlzk.erl
+++ b/src/erlzk.erl
@@ -18,7 +18,8 @@
 
 -include("erlzk.hrl").
 
--export([start/0, stop/0, connect/2, connect/3, connect/4, kill_connection/1, kill_session/1, close/1]).
+-export([start/0, stop/0, connect/2, connect/3, connect/4, close/1,
+         kill_connection/1, kill_session/1, block_incoming_data/1, unblock_incoming_data/1]).
 -export([create/2, create/3, create/4, create/5, delete/2, delete/3, exists/2, exists/3,
          get_data/2, get_data/3, set_data/3, set_data/4, get_acl/2, set_acl/3, set_acl/4,
          get_children/2, get_children/3, sync/2, get_children2/2, get_children2/3,
@@ -102,6 +103,18 @@ kill_connection(Pid) ->
 -spec kill_session(pid()) -> ok.
 kill_session(Pid) ->
     erlzk_conn:kill_session(Pid).
+
+%% @doc Block receiving data from ZooKeeper in the client.
+%%  (useful when testing network error behaviour).
+-spec block_incoming_data(pid()) -> ok.
+block_incoming_data(Pid) ->
+    erlzk_conn:block_incoming_data(Pid).
+
+%% @doc Unblock receiving data from ZooKeeper in the client.
+%%  (useful when testing network error behaviour).
+-spec unblock_incoming_data(pid()) -> ok.
+unblock_incoming_data(Pid) ->
+    erlzk_conn:block_incoming_data(Pid).
 
 %% @doc Disconnect to ZooKeeper.
 -spec close(pid()) -> ok.

--- a/src/erlzk.erl
+++ b/src/erlzk.erl
@@ -18,7 +18,7 @@
 
 -include("erlzk.hrl").
 
--export([start/0, stop/0, connect/2, connect/3, connect/4, kill_session/1, close/1]).
+-export([start/0, stop/0, connect/2, connect/3, connect/4, kill_connection/1, kill_session/1, close/1]).
 -export([create/2, create/3, create/4, create/5, delete/2, delete/3, exists/2, exists/3,
          get_data/2, get_data/3, set_data/3, set_data/4, get_acl/2, set_acl/3, set_acl/4,
          get_children/2, get_children/3, sync/2, get_children2/2, get_children2/3,
@@ -90,6 +90,12 @@ connect(ServerName, ServerList, Timeout) when is_integer(Timeout) ->
               server_list(), pos_integer(), options()) -> {ok, pid()} | {error, atom()}.
 connect(ServerName, ServerList, Timeout, Options) ->
     erlzk_conn_sup:start_conn([ServerName, ServerList, Timeout, Options]).
+
+%% @doc Cause the connection to terminate while retaining session.
+%%  (useful when testing session disconnect behaviour).
+-spec kill_connection(pid()) -> ok.
+kill_connection(Pid) ->
+    erlzk_conn:no_heartbeat(Pid).
 
 %% @doc Cause the session to terminate while retaining connection.
 %%  (useful when testing session restart behaviour).

--- a/src/erlzk_conn.erl
+++ b/src/erlzk_conn.erl
@@ -438,7 +438,7 @@ connect([Server={Host,Port}|Left], ProtocolVersion, LastZxidSeen, Timeout, LastS
             connect(Left, ProtocolVersion, LastZxidSeen, Timeout, LastSessionId, LastPassword, [Server|FailedServerList])
     end.
 
-reconnect(State=#state{servers=ServerList, auth_data=AuthData, chroot=Chroot, host=OldHost, port=OldPort,
+reconnect(State=#state{servers=ServerList, auth_data=AuthData, chroot=Chroot,
                        proto_ver=ProtoVer, zxid=Zxid, timeout=Timeout, session_id=SessionId, password=Passwd,
                        xid=Xid, reset_watch=ResetWatch, reconnect_expired=ReconnectExpired,
                        monitor=Monitor, watchers=Watchers}) ->
@@ -448,10 +448,7 @@ reconnect(State=#state{servers=ServerList, auth_data=AuthData, chroot=Chroot, ho
             RenewState = NewState#state{auth_data=AuthData, chroot=Chroot, xid=Xid, zxid=Zxid,
                                         reset_watch=ResetWatch, reconnect_expired=ReconnectExpired,
                                         monitor=Monitor, heartbeat_watcher=HeartbeatWatcher, watchers=Watchers},
-            RenewState2 = case {Host, Port} of
-                {OldHost, OldPort} -> RenewState;
-                _ -> reset_watch_return_new_state(RenewState, Watchers)
-            end,
+            RenewState2 = reset_watch_return_new_state(RenewState, Watchers),
             notify_monitor_server_state(Monitor, connected, Host, Port),
             {noreply, RenewState2, PingIntv};
         {error, {session_expired, Host, Port}} ->

--- a/test/erlzk.conf
+++ b/test/erlzk.conf
@@ -1,4 +1,4 @@
-[{"localhost",2181}].
+[{"localhost",2181}, {"localhost",2182}, {"localhost",2183}].
 30000.
 "/zk".
 [{"digest", <<"foo:bar">>}].

--- a/test/erlzk.yaml
+++ b/test/erlzk.yaml
@@ -1,0 +1,30 @@
+---
+version: '3'
+services:
+  zk1:
+    image: zookeeper:3.4.13
+    hostname: zk1
+    ports:
+      - 2181:2181
+    environment:
+      ZOO_MY_ID: 1
+      ZOO_SERVERS: server.1=0.0.0.0:2888:3888 server.2=zk2:2888:3888 server.3=zk3:2888:3888
+      ZOO_LOG4J_PROP: INFO,ROLLINGFILE
+  zk2:
+    image: zookeeper:3.4.13
+    hostname: zk2
+    ports:
+      - 2182:2181
+    environment:
+      ZOO_MY_ID: 2
+      ZOO_SERVERS: server.1=zk1:2888:3888 server.2=0.0.0.0:2888:3888 server.3=zk3:2888:3888
+      ZOO_LOG4J_PROP: INFO,ROLLINGFILE
+  zk3:
+    image: zookeeper:3.4.13
+    hostname: zk3
+    ports:
+      - 2183:2181
+    environment:
+      ZOO_MY_ID: 3
+      ZOO_SERVERS: server.1=zk1:2888:3888 server.2=zk2:2888:3888 server.3=0.0.0.0:2888:3888
+      ZOO_LOG4J_PROP: INFO,ROLLINGFILE

--- a/test/erlzk_test.erl
+++ b/test/erlzk_test.erl
@@ -12,22 +12,42 @@
                                          end).
 
 erlzk_test_() ->
-    {foreach,
-        fun setup/0,
-        [{with, [T]} || T <- [fun create/1,
-                              fun create_api/1,
-                              fun create_mode/1,
-                              fun delete/1,
-                              fun exists/1,
-                              fun get_data/1,
-                              fun set_data/1,
-                              fun get_acl/1,
-                              fun set_acl/1,
-                              fun get_children/1,
-                              fun multi/1,
-                              fun auth_data/1,
-                              fun chroot/1,
-                              fun watch/1]]}.
+    {setup,
+     fun setup_docker/0,
+     fun cleanup_docker/1,
+     {foreach,
+      fun setup/0,
+      [{with, [T]} || T <- [fun create/1,
+                            fun create_api/1,
+                            fun create_mode/1,
+                            fun delete/1,
+                            fun exists/1,
+                            fun get_data/1,
+                            fun set_data/1,
+                            fun get_acl/1,
+                            fun set_acl/1,
+                            fun get_children/1,
+                            fun multi/1,
+                            fun auth_data/1,
+                            fun chroot/1,
+                            fun watch/1]]}}.
+
+setup_docker() ->
+    Stacks = os:cmd("docker stack ls"),
+    case string:str(Stacks, ?MODULE_STRING) of
+        0 ->
+            %% Start the Docker stack
+            os:cmd("docker stack deploy -c ../test/erlzk.yaml " ?MODULE_STRING),
+            true;
+        _Exists ->
+            %% The Docker stack is already running, leave it intact
+            false
+    end.
+
+cleanup_docker(false) ->
+    ok;
+cleanup_docker(true) ->
+    os:cmd("docker stack rm " ?MODULE_STRING).
 
 setup() ->
     erlzk:start(),


### PR DESCRIPTION
Previously if `erlzk_conn` could reconnect to the same ZK host, it skipped resetting the watches. I've added tests for reconnection scenarios to both the same and to different ZK hosts, and these point out that resetting the watches is necessary in both cases.

Since the tests now need a full ZK cluster, I made them start it in Docker when necessary. I also refactored the tests a bit to avoid race conditions (assumptions such as the `erlzk_conn` would be able to connect to ZK immediately upon start, or that watch processes always terminate fast).

_Note: PR copied from huaban/erlzk#21._