### PR TITLE
Make erlzk_heartbeat:stop/1 asynchronous

### DIFF
--- a/src/erlzk.app.src
+++ b/src/erlzk.app.src
@@ -1,6 +1,6 @@
 {application, erlzk, [
     {description, "A Pure Erlang ZooKeeper Client (no C dependency)"},
-    {vsn, "0.6.5+klarna1"},
+    {vsn, "0.6.5+klarna2"},
     {registered, [erlzk_sup,erlzk_conn_sup]},
     {applications, [
         kernel,

--- a/src/erlzk_heartbeat.erl
+++ b/src/erlzk_heartbeat.erl
@@ -22,7 +22,7 @@ start(ConnPid, Interval) ->
     gen_server:start(?MODULE, [ConnPid, Interval], []).
 
 stop(Pid) ->
-    gen_server:call(Pid, stop).
+    gen_server:cast(Pid, stop).
 
 beat(Pid) ->
     gen_server:cast(Pid, beat).
@@ -33,11 +33,11 @@ beat(Pid) ->
 init([ConnPid, Interval]) ->
     {ok, #state{pid=ConnPid, interval=Interval}, Interval}.
 
-handle_call(stop, _From, State) ->
-    {stop, normal, ok, State};
 handle_call(_Request, _From, State=#state{interval=Interval}) ->
     {reply, ok, State, Interval}.
 
+handle_cast(stop, State) ->
+    {stop, normal, State};
 handle_cast(_Request, State=#state{interval=Interval}) ->
     {noreply, State, Interval}.
 


### PR DESCRIPTION
Upon timeout the `erlzk_heartbeat` process notifies `erlzk_conn` and terminates. But `erlzk_conn` in turn wants to stop `erlzk_heartbeat` too, which is no longer possible with a synchronous `gen_server:call`. Asynchronous `gen_server:cast`-s would work even if the process terminated in the meantime.