### PR TITLE
Rework the messages sent to the monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,12 @@ the options parameter is a `proplists`, support 5 option types:
 + monitor: a process receiving the message of connection state changing
 
 If you set monitor, each time erlzk is disconnected or reconnected or (reconnected after) session expired,
-will send monitor a message in the form of {State, Host, Port}, there are 3 states:
+will send monitor a message in the form of `{Pid, State, Details}`, where `Details` is a map containing some
+information relevant for the `State`. The `State` itself can be one of 3 values:
 
-+ disconnected
-+ connected
-+ expired
++ `disconnected`, in which case the details will contain the `host`, `port` and `session_id` keys.
++ `connected`, in which case the details will contain the `host`, `port`, `session_id` and `timeout` keys.
++ `expired`, in which case the details will only contain the `session_id` key.
 
 ```erlang
 {ok, Pid} = erlzk:connect([{"localhost", 2181}], 30000, [{chroot, "/zk"},

--- a/src/erlzk.app.src
+++ b/src/erlzk.app.src
@@ -1,6 +1,6 @@
 {application, erlzk, [
     {description, "A Pure Erlang ZooKeeper Client (no C dependency)"},
-    {vsn, "0.6.5+klarna2"},
+    {vsn, "0.6.5+klarna3"},
     {registered, [erlzk_sup,erlzk_conn_sup]},
     {applications, [
         kernel,


### PR DESCRIPTION
- Add the pid of the `erlzk_conn` process to the message, so a single monitor can now look after multiple connections.
- Instead of always sending the host and port in the message, report a collection of state-specific fields in a map. The monitor will receive more details this way, such as the session id or the session timeout negotiated by the client and ZooKeeper.
- Added some missing expired messages.